### PR TITLE
README.md add zh-cn translate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[简体中文](./README.zh-CN.md) | English
+
+
 # OmenMon
 
 <p align="center"><a href="https://omenmon.github.io/">Project Page &amp; Documentation</a> • <a href="https://omenmon.github.io/build">How to Build</a> • <a href="https://omenmon.github.io/build#history">Version History</a> • <a href="https://github.com/OmenMon/Localization">Translations</a> • <a href="https://github.com/OmenMon/OmenMon/releases/latest">Download ⭳</a></p>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,28 @@
+# OmenMon
+
+<p align="center"><a href="https://omenmon.github.io/">项目页面 &amp; 文档</a> • <a href="https://omenmon.github.io/build">怎么构建</a> • <a href="https://omenmon.github.io/build#history">更新历史</a> • <a href="https://github.com/OmenMon/Localization">翻译</a> • <a href="https://github.com/OmenMon/OmenMon/releases/latest">下载 ⭳</a></p>
+
+![OmenMon 图形界面预览](https://omenmon.github.io/pic/gui-overview.png)
+
+**OmenMon** 是一款轻量级的应用程序，可与您的 _HP 暗影精灵（OMEN）& 部分光影精灵（Victus）_ 机型的嵌入式控制器（EC）和 WMI BIOS 进行交互，以此做到 [查看设备温度](https://omenmon.github.io/gui#temperature) 和 [动态调整风扇速度](https://omenmon.github.io/gui#fan-control) 。它还可以帮助您自定义您最喜欢的 [键盘背光颜色](https://omenmon.github.io/gui#keyboard) 以及 [拦截 _OMEN_ 键并自定义](https://omenmon.github.io/config#key) 。
+
+**OmenMon**  致力于替代 HP 旗下游戏电脑的 _OMEN Gaming Hub（此前为OMEN Command Center）_ 的所有实用功能，而不包含几乎无用的功能。它根本不会连接到网络，没有广告、内置商店、WeGame、社交媒体集成等等。它只执行您期望它执行的操作，而不执行其他操作。
+
+**OmenMon** 旨在以最小的资源开销运行。它配备了清晰紧凑的 [图形界面](https://omenmon.github.io/gui) ，提供了很大程度的 [可配置性](https://omenmon.github.io/config) 同时还具有广泛的 [命令行模式](https://omenmon.github.io/cli) 可以手动执行各种 BIOS 和 EC 读写操作。
+
+大多数功能特定于 _HP_ 设备上的 `ACPI\PNP0C14` 驱动程序，但 [嵌入式控制器（EC）操作](https://omenmon.github.io/cli#ec) 可能适用于所有笔记本电脑。
+
+## 许可证
+
+**OmenMon** Copyright © 2023-2024 [Piotr Szczepański](https://piotr.szczepanski.name/)
+
+此应用程序是 _免费软件_：您可以根据 [自由软件基金会](https://www.fsf.org/) 发布的 [GNU 通用公共许可证版本 3](https://www.gnu.org/licenses/gpl-3.0.html#license-text) 的条款重新分发和/或修改它。许可证的全文可在该存储库或 [此处](https://omenmon.github.io/more#license) 以 `LICENSE.md` 形式提供。
+
+**OmenMon** 建立在其它几个项目的基础上。有关详细信息，请参阅 [特别致谢](https://omenmon.github.io/more#acknowledgements) 。
+
+_该软件不隶属于 HP，也不受 HP 认可。任何品牌名称仅供参考。_
+
+## 特别致谢
+
+* [XML Translator](https://github.com/Initsnow/xmltranslator) by **[@Initsnow](https://github.com/Initsnow)** – [翻译 OmenMon ](https://github.com/OmenMon/Localization)至其它语言
+* [HP Omen Sequencer Keyboard Lights Control Utility](https://github.com/slysherz/lights-for-omen-sequencer) by **[@slysherz](https://github.com/slysherz/)**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 <p align="center"><a href="https://omenmon.github.io/">项目页面 &amp; 文档</a> • <a href="https://omenmon.github.io/build">怎么构建</a> • <a href="https://omenmon.github.io/build#history">更新历史</a> • <a href="https://github.com/OmenMon/Localization">翻译</a> • <a href="https://github.com/OmenMon/OmenMon/releases/latest">下载 ⭳</a></p>
 
-![OmenMon 图形界面预览](https://omenmon.github.io/pic/gui-overview.png)
+![OmenMon 图形界面预览](https://omenmon.github.io/pic/zh-cn/gui-overview.png-zh_cn.png)
 
 **OmenMon** 是一款轻量级的应用程序，可与您的 _HP 暗影精灵（OMEN）& 部分光影精灵（Victus）_ 机型的嵌入式控制器（EC）和 WMI BIOS 进行交互，以此做到 [查看设备温度](https://omenmon.github.io/gui#temperature) 和 [动态调整风扇速度](https://omenmon.github.io/gui#fan-control) 。它还可以帮助您自定义您最喜欢的 [键盘背光颜色](https://omenmon.github.io/gui#keyboard) 以及 [拦截 _OMEN_ 键并自定义](https://omenmon.github.io/config#key) 。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -2,7 +2,7 @@
 
 <p align="center"><a href="https://omenmon.github.io/">项目页面 &amp; 文档</a> • <a href="https://omenmon.github.io/build">怎么构建</a> • <a href="https://omenmon.github.io/build#history">更新历史</a> • <a href="https://github.com/OmenMon/Localization">翻译</a> • <a href="https://github.com/OmenMon/OmenMon/releases/latest">下载 ⭳</a></p>
 
-![OmenMon 图形界面预览](https://omenmon.github.io/pic/zh-cn/gui-overview.png-zh_cn.png)
+![OmenMon 图形界面预览](https://omenmon.github.io/pic/zh-cn/gui-overview-zh_cn.png)
 
 **OmenMon** 是一款轻量级的应用程序，可与您的 _HP 暗影精灵（OMEN）& 部分光影精灵（Victus）_ 机型的嵌入式控制器（EC）和 WMI BIOS 进行交互，以此做到 [查看设备温度](https://omenmon.github.io/gui#temperature) 和 [动态调整风扇速度](https://omenmon.github.io/gui#fan-control) 。它还可以帮助您自定义您最喜欢的 [键盘背光颜色](https://omenmon.github.io/gui#keyboard) 以及 [拦截 _OMEN_ 键并自定义](https://omenmon.github.io/config#key) 。
 


### PR DESCRIPTION
Add simplified Chinese translation to readme.md 
In addition, I added the description picture of zh-cn from [omenmon.github.io](https://github.com/OmenMon/omenmon.github.io/pull/1)
PS: Why is there an extra Tencent WeGame? Because it is a special feature of OGH in China