### PR TITLE
Tempfix: faulty TNT2 monitoring

### DIFF
--- a/OmenMon.xml
+++ b/OmenMon.xml
@@ -233,9 +233,8 @@
             <Sensor Name="RTMP" Source="EC" />
             <Sensor Name="TMP1" Source="EC" />
             <Sensor Name="TNT2" Source="EC" Use="false" />
-            <Sensor Name="TNT3" Source="EC" />
+            <Sensor Name="TNT3" Source="EC" Use="false" />
             <Sensor Name="TNT4" Source="EC" />
-            <Sensor Name="TNT5" Source="EC" />
         </Temperature>
 
         <!-- Update Interval -->
@@ -267,4 +266,5 @@
     </Messages>
 
 </OmenMon>
+
 

--- a/OmenMon.xml
+++ b/OmenMon.xml
@@ -232,7 +232,7 @@
             <Sensor Name="BIOS" Source="BIOS" Use="false" />
             <Sensor Name="RTMP" Source="EC" />
             <Sensor Name="TMP1" Source="EC" />
-            <Sensor Name="TNT2" Source="EC" />
+            <Sensor Name="TNT2" Source="EC" Use="false" />
             <Sensor Name="TNT3" Source="EC" />
             <Sensor Name="TNT4" Source="EC" />
             <Sensor Name="TNT5" Source="EC" />
@@ -267,3 +267,4 @@
     </Messages>
 
 </OmenMon>
+


### PR DESCRIPTION
This PR disables monitoring for the TNT2 sensor in order to temporarily fix the "Interpretation Unknown" issue (#97) for some OMEN models and temp stuck at 84 °C or 98 °C, resulting in faulty fans control.